### PR TITLE
feat: 웹소켓 연결 및 해제와 그룹 참여 및 탈퇴 메시지 분리

### DIFF
--- a/src/main/java/com/goormi/routine/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/goormi/routine/domain/chat/controller/ChatController.java
@@ -63,4 +63,26 @@ public class ChatController {
         Long userId = Long.parseLong(principal.getName());
         chatService.handleUserLeave(roomId, userId);
     }
+    
+    @MessageMapping("/chat.online/{roomId}")
+    public void userOnline(
+            @DestinationVariable Long roomId,
+            Principal principal) {
+        
+        log.debug("User {} is now online in room {}", principal.getName(), roomId);
+        
+        Long userId = Long.parseLong(principal.getName());
+        chatService.handleUserOnline(roomId, userId);
+    }
+    
+    @MessageMapping("/chat.offline/{roomId}")
+    public void userOffline(
+            @DestinationVariable Long roomId,
+            Principal principal) {
+        
+        log.debug("User {} is now offline in room {}", principal.getName(), roomId);
+        
+        Long userId = Long.parseLong(principal.getName());
+        chatService.handleUserOffline(roomId, userId);
+    }
 }

--- a/src/main/java/com/goormi/routine/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/com/goormi/routine/domain/chat/entity/ChatMessage.java
@@ -50,9 +50,17 @@ public class ChatMessage {
     }
     
     public enum MessageType {
+        TALK,           // 일반 대화
+        NOTICE,         // 시스템 공지
+        MEMBER_JOIN,    // 그룹 멤버 가입 (영구적, DB 저장)
+        MEMBER_LEAVE,   // 그룹 멤버 탈퇴 (영구적, DB 저장)
+        ONLINE,         // 온라인 상태 (임시적, DB 저장 안함)
+        OFFLINE,        // 오프라인 상태 (임시적, DB 저장 안함)
+        
+        // 하위 호환성을 위해 유지 (deprecated)
+        @Deprecated
         ENTER,
-        TALK,
-        LEAVE,
-        NOTICE
+        @Deprecated  
+        LEAVE
     }
 }

--- a/src/main/java/com/goormi/routine/domain/chat/service/ChatService.java
+++ b/src/main/java/com/goormi/routine/domain/chat/service/ChatService.java
@@ -6,7 +6,20 @@ public interface ChatService {
     
     ChatMessageDto saveAndSendMessage(ChatMessageDto message, Long userId);
     
+    // 실제 그룹 가입/탈퇴 알림 (DB 저장)
+    ChatMessageDto notifyMemberJoin(Long roomId, Long userId);
+    
+    ChatMessageDto notifyMemberLeave(Long roomId, Long userId);
+    
+    // 온라인/오프라인 상태 관리 (DB 저장 안함)
+    void handleUserOnline(Long roomId, Long userId);
+    
+    void handleUserOffline(Long roomId, Long userId);
+    
+    // 하위 호환성을 위해 유지 (deprecated)
+    @Deprecated
     ChatMessageDto handleUserEnter(Long roomId, Long userId);
     
+    @Deprecated
     ChatMessageDto handleUserLeave(Long roomId, Long userId);
 }

--- a/src/main/java/com/goormi/routine/domain/chat/service/ChatServiceImpl.java
+++ b/src/main/java/com/goormi/routine/domain/chat/service/ChatServiceImpl.java
@@ -16,6 +16,7 @@ import com.goormi.routine.domain.user.entity.User;
 import com.goormi.routine.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,6 +34,7 @@ public class ChatServiceImpl implements ChatService {
     private final RedisMessagePublisher redisMessagePublisher;
 
     private final NotificationService notificationService;
+    private final RedisTemplate<String, Object> redisTemplate;
     
     @Override
     public ChatMessageDto saveAndSendMessage(ChatMessageDto messageDto, Long userId) {
@@ -112,6 +114,88 @@ public class ChatServiceImpl implements ChatService {
         redisMessagePublisher.publish(dto);
         
         return dto;
+    }
+    
+    @Override
+    public ChatMessageDto notifyMemberJoin(Long roomId, Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다"));
+        
+        ChatMessage message = ChatMessage.builder()
+                .roomId(roomId)
+                .userId(user.getId())
+                .senderNickname(user.getNickname())
+                .message(user.getNickname() + "님이 그룹에 참여했습니다.")
+                .messageType(MessageType.MEMBER_JOIN)
+                .build();
+        
+        ChatMessage savedMessage = chatMessageRepository.save(message);
+        ChatMessageDto dto = convertToDto(savedMessage);
+        redisMessagePublisher.publish(dto);
+        
+        log.info("Member join notification sent: {} in room {}", user.getNickname(), roomId);
+        return dto;
+    }
+    
+    @Override
+    public ChatMessageDto notifyMemberLeave(Long roomId, Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다"));
+        
+        ChatMessage message = ChatMessage.builder()
+                .roomId(roomId)
+                .userId(user.getId())
+                .senderNickname(user.getNickname())
+                .message(user.getNickname() + "님이 그룹을 나갔습니다.")
+                .messageType(MessageType.MEMBER_LEAVE)
+                .build();
+        
+        ChatMessage savedMessage = chatMessageRepository.save(message);
+        ChatMessageDto dto = convertToDto(savedMessage);
+        redisMessagePublisher.publish(dto);
+        
+        log.info("Member leave notification sent: {} in room {}", user.getNickname(), roomId);
+        return dto;
+    }
+    
+    @Override
+    public void handleUserOnline(Long roomId, Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다"));
+        
+        // Redis에 온라인 상태 저장 (DB 저장 안함)
+        redisTemplate.opsForSet().add("room:" + roomId + ":online", userId.toString());
+        
+        // 실시간으로만 전송 (DB 저장 안함)
+        ChatMessageDto dto = ChatMessageDto.builder()
+                .roomId(roomId)
+                .userId(userId)
+                .senderNickname(user.getNickname())
+                .messageType(MessageType.ONLINE)
+                .build();
+        
+        redisMessagePublisher.publish(dto);
+        log.debug("User {} is now online in room {}", user.getNickname(), roomId);
+    }
+    
+    @Override
+    public void handleUserOffline(Long roomId, Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다"));
+        
+        // Redis에서 온라인 상태 제거
+        redisTemplate.opsForSet().remove("room:" + roomId + ":online", userId.toString());
+        
+        // 실시간으로만 전송 (DB 저장 안함)
+        ChatMessageDto dto = ChatMessageDto.builder()
+                .roomId(roomId)
+                .userId(userId)
+                .senderNickname(user.getNickname())
+                .messageType(MessageType.OFFLINE)
+                .build();
+        
+        redisMessagePublisher.publish(dto);
+        log.debug("User {} is now offline in room {}", user.getNickname(), roomId);
     }
     
     private ChatMessageDto convertToDto(ChatMessage message) {

--- a/src/main/java/com/goormi/routine/domain/group/service/GroupMemberServiceImpl.java
+++ b/src/main/java/com/goormi/routine/domain/group/service/GroupMemberServiceImpl.java
@@ -18,6 +18,7 @@ import com.goormi.routine.domain.chat.entity.ChatMember;
 import com.goormi.routine.domain.chat.entity.ChatMember.MemberRole;
 import com.goormi.routine.domain.chat.repository.ChatRoomRepository;
 import com.goormi.routine.domain.chat.repository.ChatMemberRepository;
+import com.goormi.routine.domain.chat.service.ChatService;
 import com.goormi.routine.domain.userActivity.dto.UserActivityRequest;
 import com.goormi.routine.domain.userActivity.entity.ActivityType;
 import com.goormi.routine.domain.userActivity.entity.UserActivity;
@@ -45,6 +46,7 @@ public class GroupMemberServiceImpl implements GroupMemberService {
     private final NotificationService notificationService;
     private final ChatRoomRepository chatRoomRepository;
     private final ChatMemberRepository chatMemberRepository;
+    private final ChatService chatService;
 
     private final UserActivityService userActivityService;
 
@@ -108,6 +110,9 @@ public class GroupMemberServiceImpl implements GroupMemberService {
                         .isActive(true)
                         .build();
                 chatMemberRepository.save(chatMember);
+                
+                // 채팅방에 그룹 멤버 가입 알림 전송
+                chatService.notifyMemberJoin(chatRoom.getId(), userId);
             }
         }
         groupMemberRepository.save(groupMember);
@@ -195,6 +200,9 @@ public class GroupMemberServiceImpl implements GroupMemberService {
                             .isActive(true)
                             .build();
                     chatMemberRepository.save(chatMember);
+                    
+                    // 채팅방에 그룹 멤버 가입 알림 전송
+                    chatService.notifyMemberJoin(chatRoom.getId(), groupMember.getUser().getId());
                 }
             }
         }
@@ -215,6 +223,9 @@ public class GroupMemberServiceImpl implements GroupMemberService {
                 ChatMember chatMember = existingChatMember.get();
                 chatMember.setIsActive(false);
                 chatMemberRepository.save(chatMember);
+                
+                // 채팅방에 그룹 멤버 탈퇴 알림 전송
+                chatService.notifyMemberLeave(chatRoom.getId(), groupMember.getUser().getId());
             }
         }
         else if (oldStatus == GroupMemberStatus.BLOCKED ){
@@ -337,6 +348,9 @@ public class GroupMemberServiceImpl implements GroupMemberService {
             chatMember.setIsActive(false);
             chatMember.setLeftAt(java.time.LocalDateTime.now());
             chatMemberRepository.save(chatMember);
+            
+            // 채팅방에 그룹 멤버 탈퇴 알림 전송
+            chatService.notifyMemberLeave(chatRoom.getId(), userId);
         }
 
 //        groupMemberRepository.delete(groupMember);


### PR DESCRIPTION
### 기존 채팅 로직 문제점
- 웹소켓 연결을 기준으로 입장/나가기 메시지가 작성되다보니, 웹소켓 연결이 끊기는 새로고침과 같은 상황에서도 입장 및 나가기 메시지가 기록되었음

### 변경점
- 그룹 참여 및 나가기 api를 호출하여 실제로 그룹에 참여했을 때를 기준으로 알림이 가기로 함
- 웹소켓의 연결은 online/offline으로 redis에만 저장시킴