### PR TITLE
Fix: 그룹 랭킹 로직 수정

### DIFF
--- a/src/main/java/com/goormi/routine/domain/ranking/repository/RankingRepository.java
+++ b/src/main/java/com/goormi/routine/domain/ranking/repository/RankingRepository.java
@@ -28,6 +28,12 @@ public interface RankingRepository extends JpaRepository<Ranking, Long> {
 	@Query("SELECT r FROM Ranking r WHERE r.groupId = :groupId AND r.userId IS NOT NULL ORDER BY r.score DESC")
 	List<Ranking> findAllUsersByGroupIdOrderByScore(@Param("groupId") Long groupId);
 
+	@Query("SELECT r.groupId, SUM(r.score) as totalScore FROM Ranking r WHERE r.groupId IS NOT NULL GROUP BY r.groupId ORDER BY totalScore DESC")
+	List<Object[]> findGroupTotalScoresOrderByScore();
+
+	@Query("SELECT SUM(r.score) FROM Ranking r WHERE r.groupId = :groupId")
+	Optional<Integer> getTotalScoreByGroupId(@Param("groupId") Long groupId);
+
 	@Query("UPDATE Ranking r SET r.score = 0 WHERE r.groupId IS NULL")
 	void resetPersonalScores();
 

--- a/src/main/java/com/goormi/routine/domain/ranking/service/RankingServiceImpl.java
+++ b/src/main/java/com/goormi/routine/domain/ranking/service/RankingServiceImpl.java
@@ -86,14 +86,16 @@ public class RankingServiceImpl implements RankingService {
 	public List<GlobalGroupRankingResponse> getGlobalGroupRankings() {
 		String monthYear = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM"));
 
-		List<Ranking> groupRankings = rankingRepository.findGroupRankingsOrderByScore();
+		List<Object[]> groupScoreResults = rankingRepository.findGroupTotalScoresOrderByScore();
 
-		List<GroupScoreData> groupScoreList = groupRankings.stream()
-			.map(ranking -> {
-				Long groupId = ranking.getGroupId();
-				Group group = ranking.getGroup();
+		List<GroupScoreData> groupScoreList = groupScoreResults.stream()
+			.map(result -> {
+				Long groupId = (Long) result[0];
+				Integer membersTotalScore = ((Number) result[1]).intValue();
 
-				int membersTotalScore = calculateGroupMembersTotalScore(groupId);
+				Group group = rankingRepository.findByGroupId(groupId)
+					.map(Ranking::getGroup)
+					.orElse(null);
 
 				int participationBonus = calculateSimpleParticipationBonus(groupId, monthYear);
 


### PR DESCRIPTION
## 📄 작업 내용 요약
그룹 내 멤버가 점수 업데이트 시 그룹 랭킹에 개별로 조회되는 부분 수정하였습니다.
