### PR TITLE
fix: 크로스 도메인 설정 내 Secure 추가

### DIFF
--- a/src/main/java/com/goormi/routine/domain/auth/service/OAuth2SuccessHandler.java
+++ b/src/main/java/com/goormi/routine/domain/auth/service/OAuth2SuccessHandler.java
@@ -73,7 +73,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
         // 크로스 도메인 허용
         String cookieHeader = String.format(
-            "refreshToken=%s; Path=/; Max-Age=%d; HttpOnly; SameSite=None",
+            "refreshToken=%s; Path=/; Max-Age=%d; HttpOnly; SameSite=None; Secure",
             refreshToken,
             7 * 24 * 60 * 60
         );


### PR DESCRIPTION
/api/Settings 에만 토큰 문제가 발생하여 우선 크로스 도메인 허용 포맷에 SameSite=None; Secure 로 수정하였습니다.
