### PR TITLE
feat: 서브캘린더 중복이름 방지

### DIFF
--- a/src/main/java/com/goormi/routine/domain/calendar/service/CalendarServiceImpl.java
+++ b/src/main/java/com/goormi/routine/domain/calendar/service/CalendarServiceImpl.java
@@ -96,8 +96,10 @@ public class CalendarServiceImpl implements CalendarService {
         log.info("새로운 카카오 서브캘린더 생성을 시작합니다: userId={}", userId);
         try {
             // 카카오 서브캘린더 생성
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyMMdd_HHmmss");
+            String name = "routine-it for group_" + LocalDateTime.now().format(formatter);
             CreateSubCalendarRequest request = CreateSubCalendarRequest.builder()
-                    .name("routine-it for group")
+                    .name(name)
                     .color("LIME")
                     .reminder(10)
                     .build();


### PR DESCRIPTION
여러 서버에서 각각 서브 캘린더 추가 실행시 db값이 달라 새로 생성을 하는데, 
이때 같은 이름의 서브캘린더가 톡캘린더에 있으면 생성이 안됨.
이를 방지하고자 이름에 시간을 붙임