### PR TITLE
fix: chatMsg에 승인여부 추가

### DIFF
--- a/src/main/java/com/goormi/routine/domain/chat/dto/ChatMessageDto.java
+++ b/src/main/java/com/goormi/routine/domain/chat/dto/ChatMessageDto.java
@@ -20,4 +20,5 @@ public class ChatMessageDto {
     private String imageUrl;
     private MessageType messageType;
     private LocalDateTime sentAt;
+    private Boolean isApproved;
 }

--- a/src/main/java/com/goormi/routine/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/com/goormi/routine/domain/chat/entity/ChatMessage.java
@@ -39,6 +39,8 @@ public class ChatMessage {
     
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
+
+    private Boolean isApproved;
     
     @PrePersist
     protected void onCreate() {
@@ -47,6 +49,13 @@ public class ChatMessage {
 
     public boolean isAuthMessage() {
         return MessageType.NOTICE == this.messageType;
+    }
+
+    public void approveMessage() {
+        this.isApproved = true;
+    }
+    public void rejectMessage() {
+        this.isApproved = false;
     }
     
     public enum MessageType {

--- a/src/main/java/com/goormi/routine/domain/chat/service/ChatRoomServiceImpl.java
+++ b/src/main/java/com/goormi/routine/domain/chat/service/ChatRoomServiceImpl.java
@@ -233,6 +233,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
                 .imageUrl(message.getImageUrl())
                 .messageType(message.getMessageType())
                 .sentAt(message.getCreatedAt())
+                .isApproved(message.getIsApproved() != null && message.getIsApproved())
                 .build();
     }
 }

--- a/src/main/java/com/goormi/routine/domain/chat/service/ChatServiceImpl.java
+++ b/src/main/java/com/goormi/routine/domain/chat/service/ChatServiceImpl.java
@@ -66,6 +66,7 @@ public class ChatServiceImpl implements ChatService {
         if (savedMessage.isAuthMessage()){
             notificationService.createNotification(
                     NotificationType.GROUP_TODAY_AUTH_REQUEST, userId, group.getLeader().getId(), group.getGroupId());
+            savedMessage.rejectMessage();
         }
         chatMemberRepository.updateLastReadMessage(messageDto.getRoomId(), user.getId(), savedMessage.getId());
         
@@ -209,6 +210,7 @@ public class ChatServiceImpl implements ChatService {
                 .imageUrl(message.getImageUrl())
                 .messageType(message.getMessageType())
                 .sentAt(message.getCreatedAt())
+                .isApproved(message.getIsApproved() != null && message.getIsApproved())
                 .build();
     }
 }

--- a/src/main/java/com/goormi/routine/domain/group/dto/request/LeaderAnswerRequest.java
+++ b/src/main/java/com/goormi/routine/domain/group/dto/request/LeaderAnswerRequest.java
@@ -19,6 +19,7 @@ public class LeaderAnswerRequest {
     private Long groupId;
     private Long leaderId;
     private Long targetMemberId;
+    private Long chatMsgId;
 
     @Schema(description = "업데이트 할 그룹 멤버 상태")
     private GroupMemberStatus status;

--- a/src/main/java/com/goormi/routine/domain/group/service/GroupMemberServiceImpl.java
+++ b/src/main/java/com/goormi/routine/domain/group/service/GroupMemberServiceImpl.java
@@ -1,5 +1,7 @@
 package com.goormi.routine.domain.group.service;
 
+import com.goormi.routine.domain.chat.entity.ChatMessage;
+import com.goormi.routine.domain.chat.repository.ChatMessageRepository;
 import com.goormi.routine.domain.group.dto.request.GroupJoinRequest;
 import com.goormi.routine.domain.group.dto.request.LeaderAnswerRequest;
 import com.goormi.routine.domain.group.dto.response.GroupMemberResponse;
@@ -47,6 +49,7 @@ public class GroupMemberServiceImpl implements GroupMemberService {
     private final NotificationService notificationService;
     private final ChatRoomRepository chatRoomRepository;
     private final ChatMemberRepository chatMemberRepository;
+    private final ChatMessageRepository chatMessageRepository;
     private final ChatService chatService;
 
     private final UserActivityService userActivityService;
@@ -326,14 +329,19 @@ public class GroupMemberServiceImpl implements GroupMemberService {
                 .imageUrl(leaderAnswerRequest.getImageUrl())
                 .build();
 
+        ChatMessage chatMessage = chatMessageRepository.findById(leaderAnswerRequest.getChatMsgId())
+                .orElseThrow(()-> new IllegalArgumentException("chatMsg not found"));
+
         if (leaderAnswerRequest.isApproved()) {
             userActivityService.create(groupMember.getUser().getId(), activityRequest);
             notificationService.createNotification(NotificationType.GROUP_TODAY_AUTH_COMPLETED,
                     group.getLeader().getId(), groupMember.getUser().getId(), group.getGroupId());
+            chatMessage.approveMessage();
         }
         else {
             notificationService.createNotification(NotificationType.GROUP_TODAY_AUTH_REJECTED,
                     group.getLeader().getId(), groupMember.getUser().getId(), group.getGroupId());
+            chatMessage.rejectMessage();
         }
     }
 


### PR DESCRIPTION
## 📄 작업 내용 요약
리더에게 요청시 채팅메세지의 id값을 가져와서 리더의 승인요청에 따라 채팅메시지에도 승인여부가 저장되도록 수정함
