### PR TITLE
fix: 개선사항

### DIFF
--- a/src/main/java/com/goormi/routine/domain/group/dto/request/GroupCreateRequest.java
+++ b/src/main/java/com/goormi/routine/domain/group/dto/request/GroupCreateRequest.java
@@ -31,6 +31,6 @@ public class GroupCreateRequest {
     private String imageUrl;
     private int maxMembers;
 
-    private boolean isAlarm;
+    private Boolean isAlarm;
 
 }

--- a/src/main/java/com/goormi/routine/domain/group/dto/request/GroupUpdateRequest.java
+++ b/src/main/java/com/goormi/routine/domain/group/dto/request/GroupUpdateRequest.java
@@ -30,4 +30,6 @@ public class GroupUpdateRequest {
     private String category;
     private String imageUrl;
     private int maxMembers;
+
+    private Boolean isAlarm;
 }

--- a/src/main/java/com/goormi/routine/domain/group/dto/request/LeaderAnswerRequest.java
+++ b/src/main/java/com/goormi/routine/domain/group/dto/request/LeaderAnswerRequest.java
@@ -28,7 +28,7 @@ public class LeaderAnswerRequest {
 
     // 유저액티비티 request
     @Schema(description = "인증 요청 수락 여부")
-    private boolean isApproved;
+    private Boolean isApproved;
     @Schema(description = "인증 요구하는 활동 날짜")
     private LocalDate activityDate;
     @Schema(description = "활동 인증 이미지 URL")

--- a/src/main/java/com/goormi/routine/domain/group/dto/response/GroupMemberResponse.java
+++ b/src/main/java/com/goormi/routine/domain/group/dto/response/GroupMemberResponse.java
@@ -21,7 +21,7 @@ public class GroupMemberResponse {
     private GroupMemberRole role;
     @Schema(description = "메세지는 인증, 미인증 둘 중 하나를 반환합니다.")
     private String message;
-    private boolean isAlarm;
+    private Boolean isAlarm;
 
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
@@ -34,7 +34,7 @@ public class GroupMemberResponse {
                 .memberName(groupMember.getUser().getNickname())
                 .status(groupMember.getStatus())
                 .role(groupMember.getRole())
-                .isAlarm(groupMember.isAlarm())
+                .isAlarm(groupMember.getIsAlarm())
                 .createdAt(groupMember.getCreatedAt())
                 .updatedAt(groupMember.getUpdatedAt())
                 .build();
@@ -48,7 +48,7 @@ public class GroupMemberResponse {
                 .status(groupMember.getStatus())
                 .role(groupMember.getRole())
                 .message(isAuthToday == true ? "인증" : "미인증")
-                .isAlarm(groupMember.isAlarm())
+                .isAlarm(groupMember.getIsAlarm())
                 .createdAt(groupMember.getCreatedAt())
                 .updatedAt(groupMember.getUpdatedAt())
                 .build();

--- a/src/main/java/com/goormi/routine/domain/group/dto/response/GroupResponse.java
+++ b/src/main/java/com/goormi/routine/domain/group/dto/response/GroupResponse.java
@@ -45,7 +45,7 @@ public class GroupResponse {
                 .groupImageUrl(group.getGroupImageUrl())
                 .maxMembers(group.getMaxMembers())
                 .currentMemberCount(group.getCurrentMemberCnt())
-                .isAlarm(group.isAlarm())
+                .isAlarm(group.getIsAlarm())
                 .isActive(group.isActive())
                 .createdAt(group.getCreatedAt())
                 .updatedAt(group.getUpdatedAt())

--- a/src/main/java/com/goormi/routine/domain/group/entity/Group.java
+++ b/src/main/java/com/goormi/routine/domain/group/entity/Group.java
@@ -62,14 +62,14 @@ public class Group {
     @Column(nullable = false)
     private boolean isActive;
 
-    private boolean isAlarm;
+    private Boolean isAlarm;
 
 
     // 생성자
     @Builder
     private Group(User leader, String groupName, String description,
                   GroupType groupType, LocalTime alarmTime, String authDays,
-                  String category, String groupImageUrl, Integer maxMembers, boolean isAlarm ) {
+                  String category, String groupImageUrl, Integer maxMembers, Boolean isAlarm ) {
         //basicInfo
         this.leader = leader;
         this.groupName = groupName;
@@ -82,7 +82,7 @@ public class Group {
         this.category = category;
         this.groupImageUrl = groupImageUrl;
         this.maxMembers = maxMembers;
-        this.isAlarm = isAlarm;
+        this.isAlarm = isAlarm == null ? false : isAlarm;
     }
 
     // 생성 초기값은 여기서 세팅
@@ -143,6 +143,10 @@ public class Group {
         this.groupImageUrl = groupImageUrl;
         this.maxMembers = maxMembers;
         this.updatedAt = LocalDateTime.now();
+    }
+
+    public void updateIsAlarm(Boolean isAlarm) {
+        this.isAlarm = isAlarm == null ? false : isAlarm;
     }
 
 

--- a/src/main/java/com/goormi/routine/domain/group/entity/GroupMember.java
+++ b/src/main/java/com/goormi/routine/domain/group/entity/GroupMember.java
@@ -41,7 +41,7 @@ public class GroupMember {
 
     private LocalDateTime updatedAt;
 
-    private boolean isAlarm;
+    private Boolean isAlarm;
 
     @Column(name = "calendar_event_id", length = 1024)
     private String calendarEventId; // 카카오 캘린더 이벤트 ID
@@ -53,7 +53,7 @@ public class GroupMember {
         this.user = user;
         this.role = role;
         this.status = status;
-        this.isAlarm = group.isAlarm();
+        this.isAlarm = group.getIsAlarm();
     }
 
     public static GroupMember createGroupMember (Group group, User user, GroupMemberRole role, GroupMemberStatus status) {

--- a/src/main/java/com/goormi/routine/domain/group/service/GroupMemberServiceImpl.java
+++ b/src/main/java/com/goormi/routine/domain/group/service/GroupMemberServiceImpl.java
@@ -332,7 +332,7 @@ public class GroupMemberServiceImpl implements GroupMemberService {
         ChatMessage chatMessage = chatMessageRepository.findById(leaderAnswerRequest.getChatMsgId())
                 .orElseThrow(()-> new IllegalArgumentException("chatMsg not found"));
 
-        if (leaderAnswerRequest.isApproved()) {
+        if (leaderAnswerRequest.getIsApproved()) {
             userActivityService.create(groupMember.getUser().getId(), activityRequest);
             notificationService.createNotification(NotificationType.GROUP_TODAY_AUTH_COMPLETED,
                     group.getLeader().getId(), groupMember.getUser().getId(), group.getGroupId());
@@ -371,7 +371,7 @@ public class GroupMemberServiceImpl implements GroupMemberService {
         User user = userRepository.findById(userId).orElseThrow(()->new IllegalArgumentException("User not found"));
         GroupMember groupMember = groupMemberRepository.findByGroupAndUser(group, user).orElseThrow(()->new IllegalArgumentException("Member not found"));
 
-        if (isAlarm == groupMember.isAlarm()) {
+        if (isAlarm == groupMember.getIsAlarm()) {
             return;
         }
         groupMember.changeIsAlarm(isAlarm);

--- a/src/main/java/com/goormi/routine/domain/group/service/GroupServiceImpl.java
+++ b/src/main/java/com/goormi/routine/domain/group/service/GroupServiceImpl.java
@@ -58,7 +58,7 @@ public class GroupServiceImpl implements GroupService {
                 .category(request.getCategory())
                 .groupImageUrl(request.getImageUrl())
                 .maxMembers(request.getMaxMembers())
-                .isAlarm(request.isAlarm())
+                .isAlarm(request.getIsAlarm())
                 .build();
 
         group.addLeader(leader);
@@ -199,6 +199,7 @@ public class GroupServiceImpl implements GroupService {
         group.updateBasicInfo(request.getGroupName(), request.getGroupDescription(), request.getGroupType());
         group.updateTimeInfo(request.getAlarmTime(), request.getAuthDays());
         group.updateOtherInfo(request.getCategory(), request.getImageUrl(), request.getMaxMembers());
+        group.updateIsAlarm(request.getIsAlarm());
 
         // 캘린더 연동을 위한 이벤트 발행
         log.info("그룹 정보 변경 이벤트 발행: groupId={}, groupName={}", groupId, group.getGroupName());

--- a/src/main/java/com/goormi/routine/domain/group/service/GroupServiceImpl.java
+++ b/src/main/java/com/goormi/routine/domain/group/service/GroupServiceImpl.java
@@ -199,7 +199,7 @@ public class GroupServiceImpl implements GroupService {
         group.updateBasicInfo(request.getGroupName(), request.getGroupDescription(), request.getGroupType());
         group.updateTimeInfo(request.getAlarmTime(), request.getAuthDays());
         group.updateOtherInfo(request.getCategory(), request.getImageUrl(), request.getMaxMembers());
-        group.updateIsAlarm(request.getIsAlarm());
+        if(request.getIsAlarm() != null) group.updateIsAlarm(request.getIsAlarm());
 
         // 캘린더 연동을 위한 이벤트 발행
         log.info("그룹 정보 변경 이벤트 발행: groupId={}, groupName={}", groupId, group.getGroupName());

--- a/src/main/java/com/goormi/routine/domain/userActivity/entity/UserActivity.java
+++ b/src/main/java/com/goormi/routine/domain/userActivity/entity/UserActivity.java
@@ -50,23 +50,23 @@ public class UserActivity {
         this.updatedAt = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
     }
 
-    public static UserActivity createActivity (User user,PersonalRoutine personalRoutine) {
+    public static UserActivity createActivity (User user,PersonalRoutine personalRoutine, Boolean isPublic) {
         return UserActivity.builder()
                 .user(user)
                 .personalRoutine(personalRoutine)
                 .activityType(ActivityType.PERSONAL_ROUTINE_COMPLETE)
                 .activityDate(LocalDate.now(ZoneId.of("Asia/Seoul")))
-                .isPublic(false)
+                .isPublic(isPublic)
                 .build();
     }
-    public static UserActivity createActivity (User user, GroupMember groupMember, String imageUrl) {
+    public static UserActivity createActivity (User user, GroupMember groupMember, String imageUrl, Boolean isPublic) {
         return UserActivity.builder()
                 .user(user)
                 .groupMember(groupMember)
                 .imageUrl(imageUrl)
                 .activityType(ActivityType.GROUP_AUTH_COMPLETE)
                 .activityDate(LocalDate.now(ZoneId.of("Asia/Seoul")))
-                .isPublic(false)
+                .isPublic(isPublic)
                 .build();
     }
 

--- a/src/main/java/com/goormi/routine/domain/userActivity/repository/UserActivityRepository.java
+++ b/src/main/java/com/goormi/routine/domain/userActivity/repository/UserActivityRepository.java
@@ -27,6 +27,7 @@ public interface UserActivityRepository extends JpaRepository<UserActivity, Long
             LocalDate activityDate);
 
     List<UserActivity> findByUserIdAndActivityTypeOrderByCreatedAtDesc(Long userId, ActivityType activityType);
+    List<UserActivity> findByUserIdAndImageUrlIsNotNullAndActivityTypeOrderByCreatedAtDesc(Long userId, ActivityType activityType);
 
     long countByUserIdAndActivityTypeAndCreatedAtBetween(Long userId, ActivityType activityType, LocalDateTime startDate, LocalDateTime endDate);
     List<UserActivity> findByUserIdAndActivityTypeAndActivityDateBetween(Long userId, ActivityType activityType, LocalDate startDate, LocalDate endDate);

--- a/src/main/java/com/goormi/routine/domain/userActivity/service/UserActivityServiceImpl.java
+++ b/src/main/java/com/goormi/routine/domain/userActivity/service/UserActivityServiceImpl.java
@@ -47,7 +47,7 @@ public class UserActivityServiceImpl implements UserActivityService{
             GroupMember groupMember = groupMemberRepository.findByGroupAndUser(group, user)
                     .orElseThrow(() -> new IllegalArgumentException("GroupMember not found"));
 
-            userActivity = UserActivity.createActivity(user, groupMember, request.getImageUrl());
+            userActivity = UserActivity.createActivity(user, groupMember, request.getImageUrl(), request.getIsPublic());
 
         }
         else if (request.getActivityType() == ActivityType.PERSONAL_ROUTINE_COMPLETE) {
@@ -55,7 +55,7 @@ public class UserActivityServiceImpl implements UserActivityService{
 
             PersonalRoutine personalRoutine = personalRoutineRepository.findById(request.getPersonalRoutineId())
                     .orElseThrow(() -> new IllegalArgumentException("Personal Routine not found"));
-            userActivity = UserActivity.createActivity(user, personalRoutine);
+            userActivity = UserActivity.createActivity(user, personalRoutine, request.getIsPublic());
         }
         else if (request.getActivityType() == ActivityType.DAILY_CHECKLIST) {
             userActivity = UserActivity.builder()

--- a/src/main/java/com/goormi/routine/domain/userActivity/service/UserActivityServiceImpl.java
+++ b/src/main/java/com/goormi/routine/domain/userActivity/service/UserActivityServiceImpl.java
@@ -107,7 +107,7 @@ public class UserActivityServiceImpl implements UserActivityService{
                 .orElseThrow(() -> new IllegalArgumentException("Target user not found"));
 
         List<UserActivity> activities = userActivityRepository
-                .findByUserIdAndActivityTypeOrderByCreatedAtDesc(targetUserId, ActivityType.GROUP_AUTH_COMPLETE);
+                .findByUserIdAndImageUrlIsNotNullAndActivityTypeOrderByCreatedAtDesc(targetUserId, ActivityType.GROUP_AUTH_COMPLETE);
 
         boolean isOwner = targetUserId.equals(currentUserId);
 

--- a/src/test/java/com/goormi/routine/domain/group/service/GroupServiceTest.java
+++ b/src/test/java/com/goormi/routine/domain/group/service/GroupServiceTest.java
@@ -61,6 +61,7 @@ public class GroupServiceTest {
                 .groupDescription("test description")
                 .groupType(GroupType.FREE)
                 .maxMembers(3)
+                .isAlarm(true)
                 .build();
 
         GroupResponse response = groupService.createGroup(leader.getId(), request);
@@ -77,6 +78,7 @@ public class GroupServiceTest {
         assertThat(savedGroup).isNotNull();
         assertThat(savedGroup.getGroupName()).isEqualTo("test");
         assertThat(savedGroup.getGroupType()).isEqualTo(GroupType.FREE);
+        assertThat(savedGroup.getIsAlarm()).isEqualTo(true);
         assertThat(savedGroup.getLeader().getNickname()).isEqualTo(user.get().getNickname());
     }
 

--- a/src/test/java/com/goormi/routine/domain/userActivity/service/UserActivityServiceTest.java
+++ b/src/test/java/com/goormi/routine/domain/userActivity/service/UserActivityServiceTest.java
@@ -180,7 +180,7 @@ class UserActivityServiceTest {
     @DisplayName("개인 루틴 활동 생성 후 업데이트 성공")
     void update_personal_routine_activity_success() {
         // given
-        UserActivity activity = UserActivity.createActivity(user, savedRoutine);
+        UserActivity activity = UserActivity.createActivity(user, savedRoutine, true);
         userActivityRepository.save(activity);
 
         UserActivityRequest updateRequest = UserActivityRequest.builder()
@@ -205,7 +205,7 @@ class UserActivityServiceTest {
     @DisplayName("사용자 피드 조회")
     void getImagesFromUserActivity_success() {
         //given
-        UserActivity activity = UserActivity.createActivity(user, savedGroupMember, "1");
+        UserActivity activity = UserActivity.createActivity(user, savedGroupMember, "1", false);
         userActivityRepository.save(activity);
 
         UserActivity build1 = UserActivity.builder()


### PR DESCRIPTION
## 📄 작업 내용 요약
- 유저액티비티 사진조회에서 사진값있는 사진만 조회
- 유저액티비티 생성시 공개 값 받아오기
- 그룹, 리더 인증 요청 dto의 isAlarm, isApproved의 타입을 참조형으로 변경
- 그룹의 알림상태를 변경가능하도록 수정
