### PR TITLE
fix: 월간 회고 오류 수정

### DIFF
--- a/src/main/java/com/goormi/routine/domain/userActivity/repository/UserActivityRepository.java
+++ b/src/main/java/com/goormi/routine/domain/userActivity/repository/UserActivityRepository.java
@@ -40,6 +40,6 @@ public interface UserActivityRepository extends JpaRepository<UserActivity, Long
 
     List<UserActivity> findByUserIdAndActivityDateBetween(Long userId, LocalDate startDate, LocalDate endDate);
 
-    Object countByUserIdAndActivityTypeAndActivityDateBetween(Long userId, ActivityType activityType, LocalDate startDate, LocalDate endDate);
+    long countByUserIdAndActivityTypeAndActivityDateBetween(Long userId, ActivityType activityType, LocalDate startDate, LocalDate endDate);
 
 }


### PR DESCRIPTION
## 📄 작업 내용 요약
월간회고 api 호출 시 서버 에러 발생
->` runtime error: class java.lang.Long cannot be cast to class java.lang.Integer (java.lang.Long and java.lang.Integer are in module java.base of loader 'bootstrap')`

* 문제 확인
`UserActivityRepository`의 메서드가 `Object`를 반환하지만 실제로는 `Long` 타입이 반환됨
`ReviewServiceImpl`에서 이를 `(int)`로 캐스팅하려 해서 오류 발생
그리고 값이 없는 경우 `0`이 아닌 `null`로 표기 됨

* 이슈 해결
1.`UserActivityRepository` 메서드를 `Long`으로 바꾼 다음 `ReviewServiceImpl`에서 `Long` -> `int`로 변환
int 변환 시 `Math.min(값, Integer.MAX_VALUE)`로 오버플로우 방지
2.`calculateMonthlyReview`의 반환값에 `Math.max(값, 0)`으로 조건 추가

* 결과 확인
<img width="605" height="665" alt="스크린샷 2025-10-03 오후 12 16 11" src="https://github.com/user-attachments/assets/45f58cbd-2a3b-4771-a05a-69dc61a91fab" />